### PR TITLE
Refactor clients

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+type-complexity-threshold = 300

--- a/example/upload-file/src/main.rs
+++ b/example/upload-file/src/main.rs
@@ -1,3 +1,4 @@
+use std::fs::File;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -30,6 +31,7 @@ async fn main() -> Result<()> {
     // Miscellaneous code to compute some necessary values
     let mime = mime_guess::from_path(&opt.file).first_or_octet_stream();
     let file_name = opt.file.file_name().unwrap().to_str().unwrap();
+    let file = File::open(&opt.file)?;
 
     // Upload a file to drive
     let file = client
@@ -43,7 +45,7 @@ async fn main() -> Result<()> {
             },
             mime,
             file_name,
-            &opt.file,
+            file,
         )
         .await
         .context("Failed to call an API")?

--- a/example/upload-file/src/main.rs
+++ b/example/upload-file/src/main.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use misskey::{Client, HttpClient};
+use misskey::{Client, HttpClient, UploadFileClient};
 use structopt::StructOpt;
 use url::Url;
 
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
                 ..Default::default()
             },
             mime,
-            file_name,
+            file_name.to_string(),
             file,
         )
         .await

--- a/misskey-api/src/model/note.rs
+++ b/misskey-api/src/model/note.rs
@@ -4,17 +4,9 @@ use std::str::FromStr;
 use crate::model::{channel::Channel, drive::DriveFile, id::Id, user::User};
 
 use chrono::{DateTime, Utc};
-use misskey_core::streaming::SubNoteId;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
-
-/// in order to use as ID in [`streaming::note`](crate::streaming::note)
-impl From<Id<Note>> for SubNoteId {
-    fn from(id: Id<Note>) -> SubNoteId {
-        SubNoteId(id.to_string())
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
 #[serde(transparent)]

--- a/misskey-api/src/streaming/note.rs
+++ b/misskey-api/src/streaming/note.rs
@@ -37,7 +37,7 @@ mod tests {
         let note = client.create_note(Some("test"), None, None).await;
 
         let mut stream = client
-            .subscribe_note::<NoteUpdateEvent, _>(note.id)
+            .subnote::<NoteUpdateEvent, _>(note.id.to_string())
             .await
             .unwrap();
         stream.unsubscribe().await.unwrap();
@@ -53,7 +53,7 @@ mod tests {
             .create_note(Some("looks good"), None, None)
             .await;
 
-        let mut stream = client.user.subscribe_note(note.id.clone()).await.unwrap();
+        let mut stream = client.user.subnote(note.id.to_string()).await.unwrap();
 
         future::join(
             client
@@ -91,7 +91,7 @@ mod tests {
             })
             .await;
 
-        let mut stream = client.user.subscribe_note(note.id.clone()).await.unwrap();
+        let mut stream = client.user.subnote(note.id.to_string()).await.unwrap();
 
         future::join(
             client
@@ -114,7 +114,7 @@ mod tests {
         let client = TestClient::new().await;
         let note = client.user.create_note(Some("hmm..."), None, None).await;
 
-        let mut stream = client.user.subscribe_note(note.id.clone()).await.unwrap();
+        let mut stream = client.user.subnote(note.id.to_string()).await.unwrap();
 
         future::join(
             client
@@ -163,7 +163,7 @@ mod tests {
             .await
             .created_note;
 
-        let mut stream = client.user.subscribe_note(note.id.clone()).await.unwrap();
+        let mut stream = client.user.subnote(note.id.to_string()).await.unwrap();
 
         futures::future::join(
             client

--- a/misskey-core/CHANGELOG.md
+++ b/misskey-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Blanket `impl`s to `Client`
+- `UploadFileClient` for uploading files
 
 ### Changed
 

--- a/misskey-core/CHANGELOG.md
+++ b/misskey-core/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update the documentation
 - Take `io::Read` instead of file path in file uploads
+- Adjust lifetime specification of request methods

--- a/misskey-core/CHANGELOG.md
+++ b/misskey-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Blanket `impl`s to `Client`
+- `StreamingClient` for streaming connections
 - `UploadFileClient` for uploading files
 
 ### Changed

--- a/misskey-core/CHANGELOG.md
+++ b/misskey-core/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update the documentation
+- Take `io::Read` instead of file path in file uploads

--- a/misskey-core/CHANGELOG.md
+++ b/misskey-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Blanket `impl`s to `Client`
+
 ### Changed
 
 - Update the documentation

--- a/misskey-core/Cargo.toml
+++ b/misskey-core/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["async", "client", "misskey"]
 
 [dependencies]
 serde = { version = "1.0.103", features = ["derive"] }
+mime = "0.3"
 serde_json = "1.0"
 futures-core = "0.3"
 futures-sink = "0.3"

--- a/misskey-core/src/client.rs
+++ b/misskey-core/src/client.rs
@@ -1,7 +1,8 @@
-use crate::api::Request;
+use crate::api::{Request, UploadFileRequest};
 use crate::model::ApiResult;
 
 use futures_core::future::BoxFuture;
+use mime::Mime;
 
 /// Abstraction over API clients.
 pub trait Client {
@@ -47,5 +48,79 @@ impl<C: Client + ?Sized> Client for Box<C> {
         request: R,
     ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>> {
         C::request(self, request)
+    }
+}
+
+/// Abstraction over API clients that can upload files.
+pub trait UploadFileClient: Client {
+    /// Dispatches an API request with file.
+    ///
+    /// Takes the file to be attatched and [`UploadFileRequest`], then returns a future that waits for the [`Request::Response`].
+    fn request_with_file<R, T>(
+        &self,
+        request: R,
+        type_: Mime,
+        file_name: String,
+        content: T,
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>>
+    where
+        R: UploadFileRequest,
+        T: std::io::Read + Send + Sync + 'static;
+}
+
+impl<C: ?Sized> UploadFileClient for &C
+where
+    C: UploadFileClient,
+{
+    fn request_with_file<R, T>(
+        &self,
+        request: R,
+        type_: Mime,
+        file_name: String,
+        content: T,
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>>
+    where
+        R: UploadFileRequest,
+        T: std::io::Read + Send + Sync + 'static,
+    {
+        C::request_with_file(self, request, type_, file_name, content)
+    }
+}
+
+impl<C: ?Sized> UploadFileClient for &mut C
+where
+    C: UploadFileClient,
+{
+    fn request_with_file<R, T>(
+        &self,
+        request: R,
+        type_: Mime,
+        file_name: String,
+        content: T,
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>>
+    where
+        R: UploadFileRequest,
+        T: std::io::Read + Send + Sync + 'static,
+    {
+        C::request_with_file(self, request, type_, file_name, content)
+    }
+}
+
+impl<C: ?Sized> UploadFileClient for Box<C>
+where
+    C: UploadFileClient,
+{
+    fn request_with_file<R, T>(
+        &self,
+        request: R,
+        type_: Mime,
+        file_name: String,
+        content: T,
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>>
+    where
+        R: UploadFileRequest,
+        T: std::io::Read + Send + Sync + 'static,
+    {
+        C::request_with_file(self, request, type_, file_name, content)
     }
 }

--- a/misskey-core/src/client.rs
+++ b/misskey-core/src/client.rs
@@ -11,10 +11,8 @@ pub trait Client {
     /// Dispatch an API request.
     ///
     /// Takes [`Request`] and returns a future that waits for the [`Response`][`Request::Response`].
-    fn request<'a, R>(
-        &'a self,
+    fn request<R: Request>(
+        &self,
         request: R,
-    ) -> BoxFuture<'a, Result<ApiResult<R::Response>, Self::Error>>
-    where
-        R: Request + 'a;
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>>;
 }

--- a/misskey-core/src/client.rs
+++ b/misskey-core/src/client.rs
@@ -16,3 +16,36 @@ pub trait Client {
         request: R,
     ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>>;
 }
+
+impl<C: Client + ?Sized> Client for &C {
+    type Error = C::Error;
+
+    fn request<R: Request>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>> {
+        C::request(self, request)
+    }
+}
+
+impl<C: Client + ?Sized> Client for &mut C {
+    type Error = C::Error;
+
+    fn request<R: Request>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>> {
+        C::request(self, request)
+    }
+}
+
+impl<C: Client + ?Sized> Client for Box<C> {
+    type Error = C::Error;
+
+    fn request<R: Request>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ApiResult<R::Response>, Self::Error>> {
+        C::request(self, request)
+    }
+}

--- a/misskey-core/src/lib.rs
+++ b/misskey-core/src/lib.rs
@@ -7,4 +7,4 @@ pub mod model;
 pub mod streaming;
 
 pub use api::*;
-pub use client::Client;
+pub use client::*;

--- a/misskey-core/src/streaming.rs
+++ b/misskey-core/src/streaming.rs
@@ -1,30 +1,143 @@
 //! Streaming API.
 
-use std::convert::Infallible;
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use std::pin::Pin;
 
+use futures_core::{
+    future::BoxFuture,
+    stream::{BoxStream, Stream},
+};
+use futures_sink::Sink;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-/// ID of a subscribing note.
+/// Trait for [`Stream`] + [`Sink`].
 ///
-/// This unquestionably corresponds to `NoteId` in [misskey-api](https://docs.rs/misskey-api).
-/// We have a distinct ID type here because [misskey-core](https://docs.rs/misskey-core) cannot depend on [misskey-api](https://docs.rs/misskey-api) for various reasons.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
-#[serde(transparent)]
-pub struct SubNoteId(pub String);
+/// We need this for [`BoxStreamSink`] because trait objects can only have a single base trait. ([reference])
+///
+/// [reference]: https://doc.rust-lang.org/reference/types/trait-object.html
+pub trait StreamSink<I, O, E>: Stream<Item = Result<I, E>> + Sink<O, Error = E> {}
+impl<I, O, E, S: ?Sized> StreamSink<I, O, E> for S where
+    S: Sink<O, Error = E> + Stream<Item = Result<I, E>>
+{
+}
 
-impl FromStr for SubNoteId {
-    type Err = Infallible;
-    fn from_str(s: &str) -> Result<SubNoteId, Infallible> {
-        Ok(SubNoteId(s.to_string()))
+/// An owned dynamically typed [`Stream`] + [`Sink`] for use in cases where we can't statically
+/// type the result.
+pub type BoxStreamSink<'a, I, O, E> = Pin<Box<dyn StreamSink<I, O, E> + 'a + Send>>;
+
+/// Stream for the [`StreamingClient::subnote`] method.
+pub type SubNoteStream<'a, T, E> = BoxStream<'a, Result<T, E>>;
+/// Stream for the [`StreamingClient::channel`] method.
+pub type ChannelStream<'a, T, E> = BoxStreamSink<
+    'a,
+    <T as ConnectChannelRequest>::Incoming,
+    <T as ConnectChannelRequest>::Outgoing,
+    E,
+>;
+/// Stream for the [`StreamingClient::broadcast`] method.
+pub type BroadcastStream<'a, T, E> = BoxStream<'a, Result<T, E>>;
+
+/// Abstraction over API clients with streaming connections.
+pub trait StreamingClient {
+    /// The error type produced by the client when an error occurs.
+    type Error: std::error::Error;
+
+    /// Captures the note specified by `note_id`.
+    fn subnote<E: SubNoteEvent>(
+        &self,
+        note_id: String,
+    ) -> BoxFuture<Result<SubNoteStream<E, Self::Error>, Self::Error>>;
+
+    /// Connects to the channel using `request`.
+    fn channel<R: ConnectChannelRequest>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ChannelStream<R, Self::Error>, Self::Error>>;
+
+    /// Receive messages from the broadcast stream.
+    fn broadcast<E: BroadcastEvent>(
+        &self,
+    ) -> BoxFuture<Result<BroadcastStream<E, Self::Error>, Self::Error>>;
+}
+
+impl<C: ?Sized> StreamingClient for &C
+where
+    C: StreamingClient,
+{
+    type Error = C::Error;
+
+    fn subnote<E: SubNoteEvent>(
+        &self,
+        note_id: String,
+    ) -> BoxFuture<Result<SubNoteStream<E, Self::Error>, Self::Error>> {
+        C::subnote(self, note_id)
+    }
+
+    fn channel<R: ConnectChannelRequest>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ChannelStream<R, Self::Error>, Self::Error>> {
+        C::channel(self, request)
+    }
+
+    fn broadcast<E: BroadcastEvent>(
+        &self,
+    ) -> BoxFuture<Result<BroadcastStream<E, Self::Error>, Self::Error>> {
+        C::broadcast(self)
     }
 }
 
-impl Display for SubNoteId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+impl<C: ?Sized> StreamingClient for &mut C
+where
+    C: StreamingClient,
+{
+    type Error = C::Error;
+
+    fn subnote<E: SubNoteEvent>(
+        &self,
+        note_id: String,
+    ) -> BoxFuture<Result<SubNoteStream<E, Self::Error>, Self::Error>> {
+        C::subnote(self, note_id)
+    }
+
+    fn channel<R: ConnectChannelRequest>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ChannelStream<R, Self::Error>, Self::Error>> {
+        C::channel(self, request)
+    }
+
+    fn broadcast<E: BroadcastEvent>(
+        &self,
+    ) -> BoxFuture<Result<BroadcastStream<E, Self::Error>, Self::Error>> {
+        C::broadcast(self)
+    }
+}
+
+impl<C: ?Sized> StreamingClient for Box<C>
+where
+    C: StreamingClient,
+{
+    type Error = C::Error;
+
+    fn subnote<E: SubNoteEvent>(
+        &self,
+        note_id: String,
+    ) -> BoxFuture<Result<SubNoteStream<E, Self::Error>, Self::Error>> {
+        C::subnote(self, note_id)
+    }
+
+    fn channel<R: ConnectChannelRequest>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ChannelStream<R, Self::Error>, Self::Error>> {
+        C::channel(self, request)
+    }
+
+    fn broadcast<E: BroadcastEvent>(
+        &self,
+    ) -> BoxFuture<Result<BroadcastStream<E, Self::Error>, Self::Error>> {
+        C::broadcast(self)
     }
 }
 
@@ -35,7 +148,7 @@ pub trait ConnectChannelRequest: Serialize {
     /// Type of the data we receive from the channel.
     type Incoming: DeserializeOwned + 'static;
     /// Type of the data we send to the channel.
-    type Outgoing: Serialize;
+    type Outgoing: Serialize + 'static;
 
     /// The name of the channel to be connected by this request.
     const NAME: &'static str;

--- a/misskey-http/CHANGELOG.md
+++ b/misskey-http/CHANGELOG.md
@@ -11,3 +11,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Follow changes of `Client` in `misskey-core`
   - Adjust lifetime specification of request methods
+- Implement `UploadFileClient`
+  - Take `io::Read` instead of file path in file uploads

--- a/misskey-http/CHANGELOG.md
+++ b/misskey-http/CHANGELOG.md
@@ -6,3 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Follow changes of `Client` in `misskey-core`
+  - Adjust lifetime specification of request methods

--- a/misskey-http/src/client.rs
+++ b/misskey-http/src/client.rs
@@ -231,7 +231,7 @@ mod tests {
 
     use super::HttpClient;
 
-    use misskey_core::Client;
+    use misskey_core::{Client, UploadFileClient};
     use url::Url;
     use uuid::Uuid;
 
@@ -301,13 +301,14 @@ mod tests {
     async fn tokio_request_with_file() {
         let client = test_client();
         let path = write_to_temp_file("test");
+        let file = std::fs::File::open(path).unwrap();
 
         client
             .request_with_file(
                 misskey_api::endpoint::drive::files::create::Request::default(),
                 mime::TEXT_PLAIN,
                 "test.txt".to_string(),
-                path,
+                file,
             )
             .await
             .unwrap()
@@ -318,13 +319,14 @@ mod tests {
     async fn async_std_request_with_file() {
         let client = test_client();
         let path = write_to_temp_file("test");
+        let file = std::fs::File::open(path).unwrap();
 
         client
             .request_with_file(
                 misskey_api::endpoint::drive::files::create::Request::default(),
                 mime::TEXT_PLAIN,
                 "test.txt".to_string(),
-                path,
+                file,
             )
             .await
             .unwrap()

--- a/misskey-http/src/client.rs
+++ b/misskey-http/src/client.rs
@@ -154,10 +154,7 @@ impl HttpClient {
 impl Client for HttpClient {
     type Error = Error;
 
-    fn request<'a, R>(&'a self, request: R) -> BoxFuture<'a, Result<ApiResult<R::Response>>>
-    where
-        R: Request + 'a,
-    {
+    fn request<R: Request>(&self, request: R) -> BoxFuture<Result<ApiResult<R::Response>>> {
         let url = self
             .url
             .join(R::ENDPOINT)

--- a/misskey-websocket/CHANGELOG.md
+++ b/misskey-websocket/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Follow changes of `Client` in `misskey-core`
   - Adjust lifetime specification of request methods
+- Implement `StreamingClient`

--- a/misskey-websocket/CHANGELOG.md
+++ b/misskey-websocket/CHANGELOG.md
@@ -6,3 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Follow changes of `Client` in `misskey-core`
+  - Adjust lifetime specification of request methods

--- a/misskey-websocket/src/broker/handler.rs
+++ b/misskey-websocket/src/broker/handler.rs
@@ -11,12 +11,11 @@ use crate::model::{
         NoteUpdatedMessage,
     },
     outgoing::OutgoingMessage,
-    ApiRequestId, ChannelId,
+    ApiRequestId, ChannelId, SubNoteId,
 };
 
 use log::{info, warn};
 use misskey_core::model::ApiResult;
-use misskey_core::streaming::SubNoteId;
 use serde_json::value::{self, Value};
 
 #[derive(Debug)]

--- a/misskey-websocket/src/broker/model.rs
+++ b/misskey-websocket/src/broker/model.rs
@@ -5,12 +5,11 @@ use std::task::{Context, Poll};
 
 use crate::broker::channel::{ChannelPongSender, ResponseSender, ResponseStreamSender};
 use crate::error::Error;
-use crate::model::{ApiRequestId, ChannelId};
+use crate::model::{ApiRequestId, ChannelId, SubNoteId};
 
 use async_rwlock::RwLock;
 use futures::future::{BoxFuture, Future, FutureExt};
 use misskey_core::model::ApiResult;
-use misskey_core::streaming::SubNoteId;
 use serde_json::Value;
 use uuid::Uuid;
 

--- a/misskey-websocket/src/client.rs
+++ b/misskey-websocket/src/client.rs
@@ -116,10 +116,10 @@ impl WebSocketClient {
 impl Client for WebSocketClient {
     type Error = Error;
 
-    fn request<'a, R>(&'a self, request: R) -> BoxFuture<'a, Result<ApiResult<R::Response>>>
-    where
-        R: misskey_core::Request + 'a,
-    {
+    fn request<R: misskey_core::Request>(
+        &self,
+        request: R,
+    ) -> BoxFuture<Result<ApiResult<R::Response>>> {
         let id = ApiRequestId::uuid();
 
         // limit the use of `R` to the outside of `async`

--- a/misskey-websocket/src/client/stream/sub_note.rs
+++ b/misskey-websocket/src/client/stream/sub_note.rs
@@ -8,6 +8,7 @@ use crate::broker::{
     model::{BrokerControl, SharedBrokerState},
 };
 use crate::error::Result;
+use crate::model::SubNoteId;
 
 use futures::{
     executor,
@@ -15,7 +16,7 @@ use futures::{
     stream::{FusedStream, Stream, StreamExt},
 };
 use log::{info, warn};
-use misskey_core::streaming::{SubNoteEvent, SubNoteId};
+use misskey_core::streaming::SubNoteEvent;
 use serde_json::Value;
 
 /// Stream for the [`subscribe_note`][`crate::WebSocketClient::subscribe_note`] method.

--- a/misskey-websocket/src/model.rs
+++ b/misskey-websocket/src/model.rs
@@ -4,6 +4,10 @@ use uuid::Uuid;
 pub mod incoming;
 pub mod outgoing;
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
+#[serde(transparent)]
+pub struct SubNoteId(pub String);
+
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[serde(transparent)]
 pub struct ChannelId(pub Uuid);

--- a/misskey-websocket/src/model/incoming.rs
+++ b/misskey-websocket/src/model/incoming.rs
@@ -1,6 +1,5 @@
-use crate::model::{ApiRequestId, ChannelId};
+use crate::model::{ApiRequestId, ChannelId, SubNoteId};
 
-use misskey_core::streaming::SubNoteId;
 use serde::de::{self, Deserializer};
 use serde::Deserialize;
 use serde_json::Value;

--- a/misskey-websocket/src/model/outgoing.rs
+++ b/misskey-websocket/src/model/outgoing.rs
@@ -1,6 +1,5 @@
-use crate::model::{ApiRequestId, ChannelId};
+use crate::model::{ApiRequestId, ChannelId, SubNoteId};
 
-use misskey_core::streaming::SubNoteId;
 use serde::Serialize;
 use serde_json::Value;
 

--- a/misskey/src/lib.rs
+++ b/misskey/src/lib.rs
@@ -269,7 +269,7 @@ pub mod model {
     pub use misskey_core::model::*;
 }
 
-pub use misskey_core::Client;
+pub use misskey_core::{Client, UploadFileClient};
 
 #[cfg(feature = "http-client")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http-client")))]

--- a/misskey/src/lib.rs
+++ b/misskey/src/lib.rs
@@ -205,8 +205,7 @@ pub mod streaming {
     //! #     .connect()
     //! #     .await?;
     //!
-    //! let note_id: Id<Note> = "NOTE_ID_TO_WATCH".parse().unwrap();
-    //! let mut stream = client.subscribe_note(note_id).await?;
+    //! let mut stream = client.subnote("NOTE_ID_TO_WATCH").await?;
     //!
     //! loop {
     //!     // Wait for the event note using `next` method from `StreamExt`.


### PR DESCRIPTION
- Added blanket `impl`s to `Client`
- Added `StreamingClient` for streaming connections
- Added `UploadFileClient` for uploading files
- Take `io::Read` instead of file path in file uploads
- Adjust lifetime specification of request methods