### PR TITLE
Refactor the constructors of clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ use misskey::HttpClient;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-  let client = HttpClient::builder("https://your.instance.example/api/".parse()?)
-      .token("API_TOKEN".to_string())
+  let client = HttpClient::builder("https://your.instance.example/api/")
+      .token("API_TOKEN")
       .build()?;
 
   client.create_note("Hello, Misskey").await?;

--- a/example/create-note/src/main.rs
+++ b/example/create-note/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     let opt = Opt::from_args();
 
     // Create `HttpClient` with token `opt.i`
-    let client = HttpClient::new(opt.url, Some(opt.i))?;
+    let client = HttpClient::with_token(opt.url, opt.i)?;
 
     // Create a note containing `opt.text` as a text
     client.create_note(opt.text).await?;

--- a/example/follow-back/src/main.rs
+++ b/example/follow-back/src/main.rs
@@ -20,7 +20,6 @@ async fn main() -> Result<()> {
 
     // Build a client and connect to Misskey.
     let client = WebSocketClient::builder(opt.url)
-        .auto_reconnect()
         .token(opt.i)
         .connect()
         .await?;

--- a/example/ping-pong/src/main.rs
+++ b/example/ping-pong/src/main.rs
@@ -21,7 +21,6 @@ async fn main() -> Result<()> {
 
     // Build a client and connect to Misskey.
     let client = WebSocketClient::builder(opt.url)
-        .auto_reconnect()
         .token(opt.i)
         .connect()
         .await?;

--- a/example/streaming/src/main.rs
+++ b/example/streaming/src/main.rs
@@ -19,7 +19,6 @@ async fn main() -> Result<()> {
 
     // Configure and build a client using `WebSocketClientBuilder`.
     let client = WebSocketClient::builder(opt.url)
-        .auto_reconnect()
         .token(opt.i)
         .connect()
         .await?;

--- a/example/upload-file/src/main.rs
+++ b/example/upload-file/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
 
     // Create `HttpClient`.
     // Note that `HttpClient` can upload files while `WebSocketClient` can't.
-    let client = HttpClient::new(opt.url, Some(opt.i))?;
+    let client = HttpClient::with_token(opt.url, opt.i)?;
 
     // Upload a file to drive
     let mut builder = client.build_file(&opt.file);

--- a/example/word-reply/src/main.rs
+++ b/example/word-reply/src/main.rs
@@ -26,7 +26,6 @@ async fn main() -> Result<()> {
 
     // Build a client and connect to Misskey.
     let client = WebSocketClient::builder(opt.url)
-        .auto_reconnect()
         .token(opt.i)
         .connect()
         .await?;

--- a/misskey-api/src/test.rs
+++ b/misskey-api/src/test.rs
@@ -52,7 +52,7 @@ impl<T: Client + Send + Sync> ClientExt for T {
 
         (
             res.user,
-            HttpClient::new(env::api_url(), Some(res.token)).unwrap(),
+            HttpClient::with_token(env::api_url(), res.token).unwrap(),
         )
     }
 

--- a/misskey-api/src/test/http.rs
+++ b/misskey-api/src/test/http.rs
@@ -17,8 +17,8 @@ impl TestClient {
         misskey_test::init_logger();
 
         TestClient {
-            admin: HttpClient::new(env::api_url(), Some(env::admin_token())).unwrap(),
-            user: HttpClient::new(env::api_url(), Some(env::user_token())).unwrap(),
+            admin: HttpClient::with_token(env::api_url(), env::admin_token()).unwrap(),
+            user: HttpClient::with_token(env::api_url(), env::user_token()).unwrap(),
         }
     }
 }

--- a/misskey-api/src/test/websocket.rs
+++ b/misskey-api/src/test/websocket.rs
@@ -12,13 +12,11 @@ impl TestClient {
 
         let admin = WebSocketClientBuilder::new(env::websocket_url())
             .token(env::admin_token())
-            .auto_reconnect()
             .connect()
             .await
             .unwrap();
         let user = WebSocketClientBuilder::new(env::websocket_url())
             .token(env::user_token())
-            .auto_reconnect()
             .connect()
             .await
             .unwrap();

--- a/misskey-http/CHANGELOG.md
+++ b/misskey-http/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `UploadFileClient`
   - Take `io::Read` instead of file path in file uploads
 - Stop taking the token as `Option` in the constructor and provide a separate method.
+- Improve API of `HttpClientBuilder`

--- a/misskey-http/CHANGELOG.md
+++ b/misskey-http/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Adjust lifetime specification of request methods
 - Implement `UploadFileClient`
   - Take `io::Read` instead of file path in file uploads
+- Stop taking the token as `Option` in the constructor and provide a separate method.

--- a/misskey-http/Cargo.toml
+++ b/misskey-http/Cargo.toml
@@ -20,7 +20,7 @@ misskey-core = { path = "../misskey-core", version = "0.1.0" }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.2"
-url = "2.1"
+url = "2.2.0"
 isahc = "0.9.2"
 # rustc_version <= 0.2.1 fails to build openssl-sys in the dependency tree
 rustc_version = "0.2.2"

--- a/misskey-http/src/client.rs
+++ b/misskey-http/src/client.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::fmt::{self, Debug};
 
 use crate::error::{Error, Result};
@@ -60,7 +61,11 @@ impl HttpClient {
     /// All configurations are set to default.
     ///
     /// This function is identical to [`HttpClientBuilder::new`].
-    pub fn builder(url: Url) -> HttpClientBuilder {
+    pub fn builder<T>(url: T) -> HttpClientBuilder
+    where
+        T: TryInto<Url>,
+        T::Error: Into<Error>,
+    {
         HttpClientBuilder::new(url)
     }
 

--- a/misskey-http/src/client.rs
+++ b/misskey-http/src/client.rs
@@ -21,7 +21,7 @@ use builder::HttpClientBuilder;
 
 /// Asynchronous HTTP-based client for Misskey.
 ///
-/// [`HttpClient`] can be constructed using [`HttpClient::new`] or
+/// [`HttpClient`] can be constructed using [`HttpClient::new`], [`HttpClient::with_token`] or
 /// [`HttpClientBuilder`][`builder::HttpClientBuilder`].
 pub struct HttpClient {
     url: Url,
@@ -38,11 +38,20 @@ impl Debug for HttpClient {
 }
 
 impl HttpClient {
-    /// Creates a new HTTP-based client.
-    pub fn new(url: Url, token: Option<String>) -> Result<Self> {
+    /// Creates a new HTTP-based client without a token.
+    pub fn new(url: Url) -> Result<Self> {
         Ok(HttpClient {
             url,
-            token,
+            token: None,
+            client: isahc::HttpClient::new()?,
+        })
+    }
+
+    /// Creates a new HTTP-based client with a token.
+    pub fn with_token(url: Url, token: impl Into<String>) -> Result<Self> {
+        Ok(HttpClient {
+            url,
+            token: Some(token.into()),
             client: isahc::HttpClient::new()?,
         })
     }
@@ -235,7 +244,7 @@ mod tests {
 
     fn test_client() -> HttpClient {
         misskey_test::init_logger();
-        HttpClient::new(env::api_url(), Some(env::token())).unwrap()
+        HttpClient::with_token(env::api_url(), env::token()).unwrap()
     }
 
     #[test]

--- a/misskey-http/src/client/builder.rs
+++ b/misskey-http/src/client/builder.rs
@@ -1,50 +1,132 @@
-use crate::client::HttpClient;
-use crate::error::Result;
+use std::convert::TryInto;
+use std::result::Result as StdResult;
 
-use isahc::http::header::{HeaderMap, HeaderValue, IntoHeaderName};
+use crate::client::HttpClient;
+use crate::error::{Error, Result};
+
+use isahc::http::{
+    self,
+    header::{HeaderMap, HeaderName, HeaderValue},
+};
 use url::Url;
 
-/// Builder for [`HttpClient`].
-#[derive(Debug, Clone)]
-pub struct HttpClientBuilder {
+#[derive(Debug)]
+struct HttpClientBuilderInner {
     url: Url,
     token: Option<String>,
     additional_headers: HeaderMap,
 }
 
+/// Builder for [`HttpClient`].
+#[derive(Debug)]
+pub struct HttpClientBuilder {
+    inner: Result<HttpClientBuilderInner>,
+}
+
+trait ResultExt<T, E> {
+    fn err_into<U>(self) -> StdResult<T, U>
+    where
+        E: Into<U>;
+    fn and_then_mut<F>(&mut self, op: F)
+    where
+        F: FnOnce(&mut T) -> StdResult<(), E>;
+}
+
+impl<T, E> ResultExt<T, E> for StdResult<T, E> {
+    fn err_into<U>(self) -> StdResult<T, U>
+    where
+        E: Into<U>,
+    {
+        self.map_err(Into::into)
+    }
+
+    fn and_then_mut<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut T) -> StdResult<(), E>,
+    {
+        if let Ok(x) = self {
+            if let Err(e) = f(x) {
+                *self = Err(e);
+            }
+        }
+    }
+}
+
 impl HttpClientBuilder {
     /// Creates a new builder instance with `url`.
-    /// All configurations are set to default.
     ///
-    /// This function is identical to [`HttpClient::builder`].
-    pub fn new(url: Url) -> Self {
-        HttpClientBuilder {
+    /// All configurations are set to default.
+    pub fn new<T>(url: T) -> Self
+    where
+        T: TryInto<Url>,
+        T::Error: Into<Error>,
+    {
+        let inner = url.try_into().err_into().map(|url| HttpClientBuilderInner {
             url,
             token: None,
             additional_headers: HeaderMap::new(),
-        }
+        });
+        HttpClientBuilder { inner }
     }
 
-    /// Set additional headers for all requests.
-    pub fn header<K: IntoHeaderName>(&mut self, key: K, value: HeaderValue) -> &mut Self {
-        self.additional_headers.insert(key, value);
+    /// Creates a new builder instance with the given host name `host`.
+    ///
+    /// This method configures the builder with a URL of the form `https://{host}/api/`.
+    /// All other configurations are set to default.
+    pub fn with_host<S>(host: S) -> Self
+    where
+        S: AsRef<str>,
+    {
+        let url = format!("https://{}/api/", host.as_ref());
+        HttpClientBuilder::new(url.as_str())
+    }
+
+    /// Sets an additional header for all requests.
+    pub fn header<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: TryInto<HeaderName>,
+        V: TryInto<HeaderValue>,
+        K::Error: Into<http::Error>,
+        V::Error: Into<http::Error>,
+    {
+        self.inner.and_then_mut(|inner| {
+            let result = key.try_into().err_into().and_then(|key| {
+                let value = value.try_into().err_into()?;
+                Ok((key, value))
+            });
+            match result {
+                Ok((key, value)) => {
+                    inner.additional_headers.insert(key, value);
+                    Ok(())
+                }
+                Err(e) => Err(Error::Network(isahc::Error::InvalidHttpFormat(e))),
+            }
+        });
         self
     }
 
     /// Sets an API token.
-    pub fn token<S: Into<String>>(&mut self, token: S) -> &mut Self {
-        self.token = Some(token.into());
+    pub fn token<S>(mut self, token: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.inner.and_then_mut(|inner| {
+            inner.token = Some(token.into());
+            Ok(())
+        });
         self
     }
 
     /// Finish this builder instance and build [`HttpClient`].
-    pub fn build(&self) -> Result<HttpClient> {
-        Ok(HttpClient {
-            url: self.url.clone(),
-            token: self.token.clone(),
-            client: isahc::HttpClientBuilder::new()
-                .default_headers(&self.additional_headers)
-                .build()?,
+    pub fn build(self) -> Result<HttpClient> {
+        self.inner.and_then(|inner| {
+            Ok(HttpClient {
+                url: inner.url,
+                token: inner.token,
+                client: isahc::HttpClientBuilder::new()
+                    .default_headers(&inner.additional_headers)
+                    .build()?,
+            })
         })
     }
 }

--- a/misskey-http/src/error.rs
+++ b/misskey-http/src/error.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use thiserror::Error;
 
 /// Possible errors from HTTP client.
@@ -12,6 +14,15 @@ pub enum Error {
     /// JSON encode/decode error.
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+    /// Invalid URL.
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(#[from] url::ParseError),
+}
+
+impl From<Infallible> for Error {
+    fn from(x: Infallible) -> Error {
+        match x {}
+    }
 }
 
 /// Specialized Result type for operations on [`HttpClient`][`crate::HttpClient`].

--- a/misskey-test/src/lib.rs
+++ b/misskey-test/src/lib.rs
@@ -51,7 +51,7 @@ pub fn init_logger() {
 #[cfg(feature = "misskey-http")]
 pub fn test_http_client(token: String) -> Result<HttpClient> {
     init_logger();
-    let client = HttpClient::new(env::api_url(), Some(token))?;
+    let client = HttpClient::with_token(env::api_url(), token)?;
     Ok(client)
 }
 

--- a/misskey-test/src/lib.rs
+++ b/misskey-test/src/lib.rs
@@ -61,7 +61,6 @@ pub async fn test_websocket_client(token: String) -> Result<WebSocketClient> {
 
     let client = WebSocketClient::builder(env::websocket_url())
         .token(token)
-        .auto_reconnect()
         .connect()
         .await?;
 

--- a/misskey-websocket/CHANGELOG.md
+++ b/misskey-websocket/CHANGELOG.md
@@ -16,3 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Follow changes of `Client` in `misskey-core`
   - Adjust lifetime specification of request methods
 - Implement `StreamingClient`
+- Improve API of `ReconnectCondition` and `ReconnectConfig`

--- a/misskey-websocket/CHANGELOG.md
+++ b/misskey-websocket/CHANGELOG.md
@@ -18,3 +18,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `StreamingClient`
 - Improve API of `ReconnectCondition` and `ReconnectConfig`
 - Improve API of `WebSocketClient`
+- Improve API of `WebSocketClientBuilder`

--- a/misskey-websocket/CHANGELOG.md
+++ b/misskey-websocket/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Adjust lifetime specification of request methods
 - Implement `StreamingClient`
 - Improve API of `ReconnectCondition` and `ReconnectConfig`
+- Improve API of `WebSocketClient`

--- a/misskey-websocket/Cargo.toml
+++ b/misskey-websocket/Cargo.toml
@@ -24,7 +24,7 @@ misskey-core = { path = "../misskey-core", version = "0.1.0" }
 serde = { version = "1.0.83", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4.12", features = ["serde"] }
-url = "2.1"
+url = "2.2.0"
 futures = "0.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 async-tungstenite = { version = "0.8", features = ["async-tls"] }

--- a/misskey-websocket/src/client.rs
+++ b/misskey-websocket/src/client.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::fmt::{self, Debug};
 
 use crate::broker::{
@@ -73,7 +74,11 @@ impl WebSocketClient {
     /// All configurations are set to default.
     ///
     /// This function is identical to [`WebSocketClientBuilder::new`].
-    pub fn builder(url: Url) -> WebSocketClientBuilder {
+    pub fn builder<T>(url: T) -> WebSocketClientBuilder
+    where
+        T: TryInto<Url>,
+        T::Error: Into<Error>,
+    {
         WebSocketClientBuilder::new(url)
     }
 
@@ -230,7 +235,6 @@ mod tests {
 
         WebSocketClientBuilder::new(env::websocket_url())
             .token(env::token())
-            .auto_reconnect()
             .connect()
             .await
             .unwrap()

--- a/misskey-websocket/src/client.rs
+++ b/misskey-websocket/src/client.rs
@@ -56,11 +56,16 @@ impl Debug for WebSocketClient {
 
 impl WebSocketClient {
     /// Connects to Misskey using WebSocket, and returns [`WebSocketClient`].
-    ///
-    /// If `reconnect` contains [`ReconnectConfig`],
-    /// then the returned client will automatically reconnect on disconnection.
-    pub async fn connect(url: Url, reconnect: Option<ReconnectConfig>) -> Result<WebSocketClient> {
-        let (broker_tx, state) = Broker::spawn(url, reconnect).await?;
+    pub async fn connect(url: Url) -> Result<WebSocketClient> {
+        WebSocketClient::connect_with_config(url, ReconnectConfig::default()).await
+    }
+
+    /// Connects to Misskey using WebSocket with a given reconnect configuration, and returns [`WebSocketClient`].
+    pub async fn connect_with_config(
+        url: Url,
+        reconnect_config: ReconnectConfig,
+    ) -> Result<WebSocketClient> {
+        let (broker_tx, state) = Broker::spawn(url, reconnect_config).await?;
         Ok(WebSocketClient { broker_tx, state })
     }
 

--- a/misskey-websocket/src/client/builder.rs
+++ b/misskey-websocket/src/client/builder.rs
@@ -91,6 +91,10 @@ impl WebSocketClientBuilder {
             url.query_pairs_mut().append_pair("i", token);
         }
 
-        WebSocketClient::connect(url, self.reconnect.clone()).await
+        if let Some(config) = &self.reconnect {
+            WebSocketClient::connect_with_config(url, config.clone()).await
+        } else {
+            WebSocketClient::connect(url).await
+        }
     }
 }

--- a/misskey-websocket/src/client/builder.rs
+++ b/misskey-websocket/src/client/builder.rs
@@ -1,100 +1,159 @@
+use std::convert::TryInto;
+use std::result::Result as StdResult;
 use std::time::Duration;
 
 use crate::broker::{ReconnectCondition, ReconnectConfig};
 use crate::client::WebSocketClient;
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 use url::Url;
+
+#[derive(Debug, Clone)]
+struct WebSocketClientBuilderInner {
+    url: Url,
+    reconnect: ReconnectConfig,
+}
 
 /// Builder for [`WebSocketClient`].
 #[derive(Debug, Clone)]
 pub struct WebSocketClientBuilder {
-    url: Url,
-    token: Option<String>,
-    reconnect: Option<ReconnectConfig>,
+    inner: Result<WebSocketClientBuilderInner>,
+}
+
+trait ResultExt<T, E> {
+    fn and_then_mut<F>(&mut self, op: F)
+    where
+        F: FnOnce(&mut T) -> StdResult<(), E>;
+}
+
+impl<T, E> ResultExt<T, E> for StdResult<T, E> {
+    fn and_then_mut<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut T) -> StdResult<(), E>,
+    {
+        if let Ok(x) = self {
+            if let Err(e) = f(x) {
+                *self = Err(e);
+            }
+        }
+    }
 }
 
 impl WebSocketClientBuilder {
+    /// Creates a new builder instance with `url`.
+    ///
+    /// All configurations are set to default.
+    pub fn new<T>(url: T) -> Self
+    where
+        T: TryInto<Url>,
+        T::Error: Into<Error>,
+    {
+        let inner = url
+            .try_into()
+            .map_err(Into::into)
+            .map(|url| WebSocketClientBuilderInner {
+                url,
+                reconnect: ReconnectConfig::default(),
+            });
+
+        WebSocketClientBuilder { inner }
+    }
+
+    /// Creates a new builder instance with the given host name `host`.
+    ///
+    /// This method configures the builder with a URL of the form `wss://{host}/streaming`.
+    /// All other configurations are set to default.
+    pub fn with_host<S>(host: S) -> Self
+    where
+        S: AsRef<str>,
+    {
+        let url = format!("wss://{}/streaming", host.as_ref());
+        WebSocketClientBuilder::new(url.as_str())
+    }
+
+    /// Sets an API token.
+    ///
+    /// This method appends the given token as the `i` query parameter to the URL.
+    pub fn token<S>(&mut self, token: S) -> &mut Self
+    where
+        S: AsRef<str>,
+    {
+        self.query("i", token)
+    }
+
     /// Specifies additional query parameters for the URL.
     pub fn query<S1, S2>(&mut self, key: S1, value: S2) -> &mut Self
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
     {
-        self.url
-            .query_pairs_mut()
-            .append_pair(key.as_ref(), value.as_ref());
+        self.inner.and_then_mut(|inner| {
+            inner
+                .url
+                .query_pairs_mut()
+                .append_pair(key.as_ref(), value.as_ref());
+            Ok(())
+        });
         self
     }
 
-    /// Creates a new builder instance with `url`.
-    /// All configurations are set to default.
+    /// Sets whether or not to enable automatic reconnection.
     ///
-    /// This function is identical to [`WebSocketClient::builder`].
-    pub fn new(url: Url) -> Self {
-        WebSocketClientBuilder {
-            url,
-            token: None,
-            reconnect: None,
+    /// Automatic reconnection is enabled by default (as per [`Default`][default] implementation for
+    /// [`ReconnectConfig`]), and you can disable it with `.auto_reconnect(false)`.
+    ///
+    /// [default]: std::default::Default
+    pub fn auto_reconnect(&mut self, enable: bool) -> &mut Self {
+        if enable {
+            self.reconnect_condition(ReconnectCondition::unexpected_reset())
+        } else {
+            self.reconnect_condition(ReconnectCondition::never())
         }
-    }
-
-    /// Sets an API token.
-    pub fn token<S: Into<String>>(&mut self, token: S) -> &mut Self {
-        self.token = Some(token.into());
-        self
-    }
-
-    /// Enables automatic reconnection.
-    pub fn auto_reconnect(&mut self) -> &mut Self {
-        self.reconnect = Some(ReconnectConfig::default());
-        self
     }
 
     /// Sets an interval duration of automatic reconnection in seconds.
     pub fn reconnect_secs(&mut self, secs: u64) -> &mut Self {
-        self.reconnect
-            .get_or_insert_with(ReconnectConfig::default)
-            .interval = Duration::from_secs(secs);
+        self.inner.and_then_mut(|inner| {
+            inner.reconnect.interval = Duration::from_secs(secs);
+            Ok(())
+        });
         self
     }
 
     /// Sets an interval duration of automatic reconnection.
     pub fn reconnect_interval(&mut self, interval: Duration) -> &mut Self {
-        self.reconnect
-            .get_or_insert_with(ReconnectConfig::default)
-            .interval = interval;
+        self.inner.and_then_mut(|inner| {
+            inner.reconnect.interval = interval;
+            Ok(())
+        });
         self
     }
 
     /// Specifies the condition for reconnecting.
     pub fn reconnect_condition(&mut self, condition: ReconnectCondition) -> &mut Self {
-        self.reconnect
-            .get_or_insert_with(ReconnectConfig::default)
-            .condition = condition;
+        self.inner.and_then_mut(|inner| {
+            inner.reconnect.condition = condition;
+            Ok(())
+        });
         self
     }
 
     /// Specifies whether to re-send messages that may have failed to be sent when reconnecting.
     pub fn reconnect_retry_send(&mut self, enable: bool) -> &mut Self {
-        self.reconnect
-            .get_or_insert_with(ReconnectConfig::default)
-            .retry_send = enable;
+        self.inner.and_then_mut(|inner| {
+            inner.reconnect.retry_send = enable;
+            Ok(())
+        });
         self
     }
 
     /// Finish this builder instance and connect to Misskey using this configuration.
     pub async fn connect(&self) -> Result<WebSocketClient> {
-        let mut url = self.url.clone();
+        let WebSocketClientBuilderInner { url, reconnect } = match self.inner.clone() {
+            Err(e) => return Err(e),
+            Ok(inner) => inner,
+        };
 
-        if let Some(token) = &self.token {
-            url.query_pairs_mut().append_pair("i", token);
-        }
-
-        if let Some(config) = &self.reconnect {
-            WebSocketClient::connect_with_config(url, config.clone()).await
-        } else {
-            WebSocketClient::connect(url).await
-        }
+        WebSocketClient::connect_with_config(url, reconnect).await
     }
 }

--- a/misskey-websocket/src/error.rs
+++ b/misskey-websocket/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::sync::Arc;
 
 use async_tungstenite::tungstenite;
@@ -15,6 +16,18 @@ pub enum Error {
     /// JSON encode/decode error.
     #[error("JSON error: {0}")]
     Json(#[source] Arc<serde_json::Error>),
+}
+
+impl From<Infallible> for Error {
+    fn from(x: Infallible) -> Error {
+        match x {}
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(_: url::ParseError) -> Error {
+        tungstenite::Error::Url("Failed to parse URL".into()).into()
+    }
 }
 
 impl From<tungstenite::Error> for Error {

--- a/misskey/src/lib.rs
+++ b/misskey/src/lib.rs
@@ -21,8 +21,8 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> anyhow::Result<()> {
-//! let client = HttpClient::builder("https://your.instance.example/api/".parse()?)
-//!     .token("API_TOKEN".to_string())
+//! let client = HttpClient::builder("https://your.instance.example/api/")
+//!     .token("API_TOKEN")
 //!     .build()?;
 //!
 //! client.create_note("Hello, Misskey").await?;

--- a/misskey/src/lib.rs
+++ b/misskey/src/lib.rs
@@ -147,7 +147,7 @@ pub mod endpoint {
     //! # use misskey::{Client, HttpClient};
     //! # #[tokio::main]
     //! # async fn main() -> anyhow::Result<()> {
-    //! # let client = HttpClient::new("http://your.instance.example/api/".parse()?, Some("API_TOKEN".to_string()))?;
+    //! # let client = HttpClient::with_token("http://your.instance.example/api/".parse()?, "API_TOKEN")?;
     //! client
     //!     .request(
     //!         // Each endpoint implementation has a corresponding `Request` type.
@@ -175,7 +175,7 @@ pub mod endpoint {
     //! # use misskey::{Client, HttpClient};
     //! # #[tokio::main]
     //! # async fn main() -> anyhow::Result<()> {
-    //! # let client = HttpClient::new("http://your.instance.example/api/".parse()?, Some("API_TOKEN".to_string()))?;
+    //! # let client = HttpClient::with_token("http://your.instance.example/api/".parse()?, "API_TOKEN")?;
     //!     let me = client
     //!         .request(misskey::endpoint::i::Request::default())
     //!         .await?

--- a/misskey/src/lib.rs
+++ b/misskey/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> anyhow::Result<()> {
-//! let client = WebSocketClient::builder("wss://your.instance.example/streaming".parse()?)
+//! let client = WebSocketClient::builder("wss://your.instance.example/streaming")
 //!     .token("YOUR_API_TOKEN")
 //!     .connect()
 //!     .await?;
@@ -205,7 +205,7 @@ pub mod streaming {
     //! # use misskey::WebSocketClient;
     //! # #[tokio::main]
     //! # async fn main() -> anyhow::Result<()> {
-    //! # let client = WebSocketClient::builder("ws://your.instance.example/streaming".parse()?)
+    //! # let client = WebSocketClient::builder("wss://your.instance.example/streaming")
     //! #     .token("API_TOKEN")
     //! #     .connect()
     //! #     .await?;
@@ -231,7 +231,7 @@ pub mod streaming {
     //! # use misskey::WebSocketClient;
     //! # #[tokio::main]
     //! # async fn main() -> anyhow::Result<()> {
-    //! # let client = WebSocketClient::builder("ws://your.instance.example/streaming".parse()?)
+    //! # let client = WebSocketClient::builder("wss://your.instance.example/streaming")
     //! #     .token("API_TOKEN")
     //! #     .connect()
     //! #     .await?;
@@ -269,7 +269,7 @@ pub mod streaming {
     //! # use misskey::WebSocketClient;
     //! # #[tokio::main]
     //! # async fn main() -> anyhow::Result<()> {
-    //! # let client = WebSocketClient::builder("ws://your.instance.example/streaming".parse()?)
+    //! # let client = WebSocketClient::builder("wss://your.instance.example/streaming")
     //! #     .token("API_TOKEN")
     //! #     .connect()
     //! #     .await?;


### PR DESCRIPTION
- Stop taking the token as `Option` in the constructor and provide a separate method.
- Improve API of builders