### PR TITLE
Accept additional headers for WebSocketClient

### DIFF
--- a/misskey-websocket/CHANGELOG.md
+++ b/misskey-websocket/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Accept additional headers for `WebSocketClient`
+
 ### Changed
 
 - Use tokio 1.0 and async-tungstenite 0.13

--- a/misskey-websocket/src/broker.rs
+++ b/misskey-websocket/src/broker.rs
@@ -33,7 +33,7 @@ pub(crate) struct Broker {
     handler: Handler,
     reconnect: ReconnectConfig,
     uri: Uri,
-    headers: HeaderMap,
+    additional_headers: HeaderMap,
 }
 
 /// Specifies the condition for reconnecting.
@@ -182,7 +182,7 @@ impl Broker {
     pub async fn spawn(
         uri: Uri,
         reconnect: ReconnectConfig,
-        headers: HeaderMap,
+        additional_headers: HeaderMap,
     ) -> Result<(ControlSender, SharedBrokerState)> {
         let state = SharedBrokerState::working();
         let shared_state = SharedBrokerState::clone(&state);
@@ -192,7 +192,7 @@ impl Broker {
         task::spawn(async move {
             let mut broker = Broker {
                 uri,
-                headers,
+                additional_headers,
                 broker_rx,
                 reconnect,
                 handler: Handler::new(),
@@ -265,7 +265,7 @@ impl Broker {
         use futures_util::future::{self, Either};
 
         let (mut websocket_tx, mut websocket_rx) =
-            match connect_websocket(self.uri.clone(), self.headers.clone()).await {
+            match connect_websocket(self.uri.clone(), self.additional_headers.clone()).await {
                 Ok(x) => x,
                 Err(error) => {
                     // retain `remaining_message` because we've not sent it yet

--- a/misskey-websocket/src/channel.rs
+++ b/misskey-websocket/src/channel.rs
@@ -12,6 +12,7 @@ use async_tungstenite::async_std::{connect_async, ConnectStream};
 use async_tungstenite::tokio::{connect_async, ConnectStream};
 use async_tungstenite::tungstenite::{
     error::{Error as WsError, Result as WsResult},
+    http::{self, header::HeaderMap},
     Message as WsMessage,
 };
 use async_tungstenite::WebSocketStream;
@@ -21,7 +22,6 @@ use futures_util::{
 };
 #[cfg(feature = "inspect-contents")]
 use log::debug;
-use url::Url;
 
 /// Receiver channel that communicates with Misskey
 pub struct WebSocketReceiver(SplitStream<PingPongWebSocketStream<WebSocketStream<ConnectStream>>>);
@@ -211,8 +211,15 @@ where
     }
 }
 
-pub async fn connect_websocket(url: Url) -> Result<(WebSocketSender, WebSocketReceiver)> {
-    let (ws, _) = connect_async(url).await?;
+pub async fn connect_websocket(
+    uri: http::Uri,
+    headers: HeaderMap,
+) -> Result<(WebSocketSender, WebSocketReceiver)> {
+    let mut request = http::Request::builder().uri(uri);
+    for (key, value) in headers.iter() {
+        request = request.header(key, value);
+    }
+    let (ws, _) = connect_async(request.body(()).unwrap()).await?;
     let (sink, stream) = PingPongWebSocketStream::new(ws).split();
     Ok((WebSocketSender(sink), WebSocketReceiver(stream)))
 }

--- a/misskey-websocket/src/client/builder.rs
+++ b/misskey-websocket/src/client/builder.rs
@@ -87,7 +87,7 @@ impl WebSocketClientBuilder {
         WebSocketClientBuilder::new(url.as_str())
     }
 
-    /// Sets a header for the connection request.
+    /// Sets an additional header for the connection request.
     pub fn header<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
         K: TryInto<HeaderName>,

--- a/misskey-websocket/src/client/builder.rs
+++ b/misskey-websocket/src/client/builder.rs
@@ -65,7 +65,7 @@ impl WebSocketClientBuilder {
     {
         let inner = url
             .try_into()
-            .map_err(Into::into)
+            .err_into()
             .map(|url| WebSocketClientBuilderInner {
                 url,
                 additional_headers: HeaderMap::new(),

--- a/misskey-websocket/src/client/builder.rs
+++ b/misskey-websocket/src/client/builder.rs
@@ -105,7 +105,7 @@ impl WebSocketClientBuilder {
                     inner.additional_headers.insert(key, value);
                     Ok(())
                 }
-                Err(e) => Err(Error::WebSocket(Arc::new(e.into()))),
+                Err(e) => Err(Error::InvalidHeader(Arc::new(e.into()))),
             }
         });
         self

--- a/misskey-websocket/src/client/builder.rs
+++ b/misskey-websocket/src/client/builder.rs
@@ -105,7 +105,7 @@ impl WebSocketClientBuilder {
                     inner.additional_headers.insert(key, value);
                     Ok(())
                 }
-                Err(e) => Err(Error::InvalidHeader(Arc::new(e.into()))),
+                Err(e) => Err(Error::InvalidHeader(Arc::new(e))),
             }
         });
         self

--- a/misskey-websocket/src/error.rs
+++ b/misskey-websocket/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     /// JSON encode/decode error.
     #[error("JSON error: {0}")]
     Json(#[source] Arc<serde_json::Error>),
+    /// Invalid header.
+    #[error("Invalid header: {0}")]
+    InvalidHeader(#[source] Arc<tungstenite::http::Error>),
 }
 
 impl From<Infallible> for Error {


### PR DESCRIPTION
This PR allows users to add their custom headers to websocket requests. Added `header` method to `WebSocketClientBuilder` so that they can be specified in the same way as that of `HttpClientBuilder`.